### PR TITLE
Feature/code templates

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { Route, Switch } from 'react-router-dom'
 import Workspace from "./views/Workspace/Workspace"
 import Home from "./views/Home/Home"
@@ -6,10 +6,6 @@ import NotFound from "./views/NotFound"
 
 const App = () => {
     const [selectedActivity, setSelectedActivity] = useState()
-
-    useEffect(() => {
-        console.log("Selected activity has changed to: ", selectedActivity)
-    }, [selectedActivity])
 
     return (
         <div>

--- a/client/src/views/Home/Home.js
+++ b/client/src/views/Home/Home.js
@@ -9,6 +9,7 @@ function Home(props) {
     const [activities, setActivities] = useState([]) // temporary - eventually topics should render their activities
 
     useEffect(() => {
+        localStorage.clear()
 
         getTopics().then(topics => {
 

--- a/client/src/views/Workspace/Workspace.js
+++ b/client/src/views/Workspace/Workspace.js
@@ -23,14 +23,11 @@ function App(props) {
         const {selectedActivity} = props
 
         if (localActivity && !selectedActivity) {
-
             let loadedActivity = JSON.parse(localActivity)
             setActivity(loadedActivity)
 
         } else if (selectedActivity) {
-
             getActivityToolbox(selectedActivity.id).then(response => {
-
                 let loadedActivity = {...selectedActivity, toolbox: response.toolbox}
 
                 localStorage.setItem("my-activity", JSON.stringify(loadedActivity))

--- a/client/src/views/Workspace/Workspace.js
+++ b/client/src/views/Workspace/Workspace.js
@@ -1,12 +1,13 @@
 import React, { useEffect, useRef, useState } from "react"
 import { Link } from "react-router-dom"
-import { compileArduinoCode, getArduino, getJS } from './helpers.js'
+import { compileArduinoCode, getArduino, getJS, getXml } from './helpers.js'
 import "./Workspace.css"
 import { getActivityToolbox } from "../../dataaccess/requests.js"
 
 function App(props) {
 
     const [activity, setActivity] = useState({})
+    const [hoverXml, setHoverXml] = useState(false)
     const [hoverJS, setHoverJS] = useState(false)
     const [hoverArduino, setHoverArduino] = useState(false)
     const [hoverCompile, setHoverCompile] = useState(false)
@@ -45,7 +46,14 @@ function App(props) {
     useEffect(() => {
 
         // once the activity state is set, set the workspace
-        if (Object.keys(activity).length && !workspaceRef.current) setWorkspace()
+        if (Object.keys(activity).length && !workspaceRef.current) {
+            setWorkspace()
+
+            if (activity.template) {
+                let xml = window.Blockly.Xml.textToDom(activity.template)
+                window.Blockly.Xml.domToWorkspace(xml, workspaceRef.current)
+            }
+        }
     }, [activity])
 
     return (
@@ -54,6 +62,10 @@ function App(props) {
                 <div id="nav-container" className="flex vertical-container space-between">
                     <h1 id="title"><Link to={"/"}>STEM+C</Link></h1>
                     <div id="action-btn-container" className="flex space-between">
+                        <i onClick={() => getXml(workspaceRef.current)} className="fas fa-code hvr-info"
+                           onMouseEnter={() => setHoverXml(true)}
+                           onMouseLeave={() => setHoverXml(false)}/>
+                        {hoverXml && <div className="popup JS">Shows Xml Code</div>}
                         <i onClick={() => getJS(workspaceRef.current)} className="fab fa-js hvr-info"
                            onMouseEnter={() => setHoverJS(true)}
                            onMouseLeave={() => setHoverJS(false)}/>

--- a/client/src/views/Workspace/helpers.js
+++ b/client/src/views/Workspace/helpers.js
@@ -31,10 +31,10 @@ export const getJS = (workspaceRef) => {
 };
 
 // Generates Arduino code from blockly canvas
-export const getArduino = (workspaceRef) => {
+export const getArduino = (workspaceRef, alert = true) => {
     window.Blockly.Arduino.INFINITE_LOOP_TRAP = null;
     let code = window.Blockly.Arduino.workspaceToCode(workspaceRef);
-    alert(code);
+    if(alert) alert(code);
     return (code);
 };
 
@@ -42,7 +42,7 @@ export const getArduino = (workspaceRef) => {
 export const compileArduinoCode = async (workspaceRef) => {
     let body = {
         "board": "arduino:avr:uno",
-        "sketch": getArduino(workspaceRef)
+        "sketch": getArduino(workspaceRef, false)
     };
 
     // gets compiled hex from server

--- a/client/src/views/Workspace/helpers.js
+++ b/client/src/views/Workspace/helpers.js
@@ -3,6 +3,17 @@ import { compileCode } from "../../dataaccess/requests";
 const AvrboyArduino = window.AvrgirlArduino;
 
 // Generates javascript code from blockly canvas
+export const getXml = (workspaceRef) => {
+    
+    const { Blockly } = window 
+
+    let xml = Blockly.Xml.workspaceToDom(workspaceRef)
+    let xml_text = Blockly.Xml.domToText(xml)
+    alert(xml_text);
+    return (xml_text);
+};
+
+// Generates javascript code from blockly canvas
 export const getJS = (workspaceRef) => {
     window.Blockly.JavaScript.INFINITE_LOOP_TRAP = null;
     let code = window.Blockly.JavaScript.workspaceToCode(workspaceRef);

--- a/client/src/views/Workspace/helpers.js
+++ b/client/src/views/Workspace/helpers.js
@@ -2,7 +2,16 @@ import { compileCode } from "../../dataaccess/requests";
 
 const AvrboyArduino = window.AvrgirlArduino;
 
-// Generates javascript code from blockly canvas
+export const setLocalActivity = (workspaceRef) => {
+    let workspaceDom = window.Blockly.Xml.workspaceToDom(workspaceRef)
+    let workspaceText = window.Blockly.Xml.domToText(workspaceDom)
+    const localActivity = JSON.parse(localStorage.getItem("my-activity"))
+
+    let lastActivity = {...localActivity, template: workspaceText}
+    localStorage.setItem("my-activity", JSON.stringify(lastActivity))
+}
+
+// Generates xml from blockly canvas
 export const getXml = (workspaceRef) => {
     
     const { Blockly } = window 

--- a/cms/api/activity/models/activity.settings.json
+++ b/cms/api/activity/models/activity.settings.json
@@ -26,11 +26,11 @@
     "learning_category": {
       "model": "learning-category"
     },
-    "topic": {
-      "model": "topic"
-    },
     "blocks": {
       "collection": "block"
+    },
+    "template": {
+      "type": "text"
     }
   }
 }

--- a/cms/api/topic/models/topic.settings.json
+++ b/cms/api/topic/models/topic.settings.json
@@ -24,8 +24,7 @@
       "model": "type"
     },
     "activities": {
-      "collection": "activity",
-      "via": "topic"
+      "collection": "activity"
     }
   }
 }


### PR DESCRIPTION
Closes #17 

- Activities now can contain an xml of the workspace to be loaded
- Workspace view can now render xml templates in blockly workspace
- Workspace now stored in local cache and persists across page refresh
- Toolbox now located separate from the activity and is requested based on activity